### PR TITLE
Move ephemeral dir to `~/.qubesome/run`

### DIFF
--- a/internal/files/files.go
+++ b/internal/files/files.go
@@ -3,8 +3,8 @@
 // Key locations:
 // - ~/.qubesome: default location for persistent files.
 // - ~/.qubesome/images-last-checked: file that stores when images were last checked.
-// - /run/user/%d/qubesome: root of ephemeral files.
-// - /run/user/%d/qubesome/git/<git-url>/<path>: where git repositories
+// - ~/.qubesome/run: root of ephemeral files.
+// - ~/.qubesome/git/<git-url>/<path>: where git repositories
 // are cloned to.
 package files
 
@@ -53,7 +53,7 @@ func ImagesLastCheckedPath() string {
 
 // RunUserQubesome returns the path to the user-specific qubesome directory.
 func RunUserQubesome() string {
-	return fmt.Sprintf("/run/user/%d/qubesome", os.Getuid())
+	return filepath.Join(QubesomeDir(), "run")
 }
 
 // ClientCookiePath returns the path to the client cookie file for the given profile.

--- a/internal/profiles/profiles.go
+++ b/internal/profiles/profiles.go
@@ -269,7 +269,12 @@ func Start(runner string, profile *types.Profile, cfg *types.Config) (err error)
 	}()
 
 	defer func() {
-		_ = os.Remove(sockPath)
+		// Clean up the profile dir once profile finishes.
+		pd := files.ProfileDir(profile.Name)
+		err = os.RemoveAll(pd)
+		if err != nil {
+			slog.Warn("failed to remove profile dir", "path", pd, "error", err)
+		}
 	}()
 
 	err = createMagicCookie(profile)


### PR DESCRIPTION
Previously the ephemeral dir for qubesome was kept at `/run/user/1000/qubesome`, this has now moved to `~/.qubesome/run` instead. Profile dirs are created inside the new dir and removed once 'qubesome start' finishes.

The default git location has also changed to `~/.qubesome/git`.