### PR TITLE
Fix issue trying to start profiles

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,8 +4,16 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      golang.org:
+        patterns:
+          - "golang.org/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      github-actions-updates:
+        patterns:
+          - "*"

--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -18,17 +18,3 @@ testbuild:
               - aarch64
   filters:
     event: pull_request
-
-rebuild:
-  steps:
-    - trigger_services:
-        project: home:pjbgf:devel:languages:go:unstable
-        package: qubesome
-    - rebuild_package:
-        project: home:pjbgf:devel:languages:go:unstable
-        package: qubesome
-  filters:
-    event: push
-    branches:
-      only:
-        - main

--- a/internal/profiles/profiles.go
+++ b/internal/profiles/profiles.go
@@ -86,10 +86,10 @@ func StartFromGit(runner, name, gitURL, path, local string) error {
 	ln := files.ProfileConfig(name)
 
 	if _, err := os.Lstat(ln); err == nil {
-		// Wayland is not cleaning up profile state after closure.
-		if !strings.EqualFold(os.Getenv("XDG_SESSION_TYPE"), "wayland") {
+		if container.Running(runner, fmt.Sprintf(ContainerNameFormat, name)) {
 			return fmt.Errorf("profile %q is already started", name)
 		}
+
 		if err = os.Remove(ln); err != nil {
 			return fmt.Errorf("failed to remove leftover profile symlink: %w", err)
 		}


### PR DESCRIPTION
Abrupt stops of `qubesome start` leave behind lingering files which may lead `qubesome` to think the profile is still running. To overcome this issue, a new check was introduced to confirm that the container is running before returning an error.