### PR TITLE
profiles: Daemonise profile start

### DIFF
--- a/cmd/cli/start.go
+++ b/cmd/cli/start.go
@@ -2,10 +2,16 @@ package cli
 
 import (
 	"context"
+	"log/slog"
+	"os"
+	"os/exec"
+	"syscall"
 
 	"github.com/qubesome/cli/internal/profiles"
 	"github.com/urfave/cli/v3"
 )
+
+var selfcall bool
 
 func startCommand() *cli.Command {
 	cmd := &cli.Command{
@@ -37,6 +43,11 @@ qubesome start -git https://github.com/qubesome/sample-dotfiles i3
 				Name:        "runner",
 				Destination: &runner,
 			},
+			&cli.BoolFlag{
+				Sources:     cli.EnvVars("QUBESOME_SELFCALL"),
+				Destination: &selfcall,
+				Hidden:      true,
+			},
 		},
 		Arguments: []cli.Argument{
 			&cli.StringArg{
@@ -47,6 +58,32 @@ qubesome start -git https://github.com/qubesome/sample-dotfiles i3
 			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
+			// When a profile is started, it starts an inception server
+			// so that the containerised Windows Manager is able to execute
+			// new container workloads. This self-calls qubesome and leave it
+			// running so that the main process exits right away.
+			if !selfcall {
+				cmd := exec.Command(os.Args[0], os.Args[1:]...) //nolint
+				cmd.Env = append(cmd.Env, "QUBESOME_SELFCALL=true")
+				cmd.Env = append(cmd.Env, os.Environ()...)
+				cmd.Stdout = nil
+				cmd.Stderr = nil
+
+				cmd.SysProcAttr = &syscall.SysProcAttr{
+					Setsid: true,
+				}
+
+				if err := cmd.Start(); err != nil {
+					slog.Error("failed to daemonise profile start",
+						"cmd", os.Args[0], "args", os.Args[1:])
+					return err
+				}
+
+				slog.Error("profile start daemon", "pid", cmd.Process.Pid,
+					"cmd", os.Args[0], "args", os.Args[1:])
+				os.Exit(0)
+			}
+
 			return profiles.Run(
 				profiles.WithProfile(targetProfile),
 				profiles.WithGitURL(gitURL),


### PR DESCRIPTION
When a profile is started, it starts an inception server so that the containerised Windows Manager is able to execute new container workloads. The previous implementation required the start command to hold the process running for as long as the profile was running.

These changes act as a self-daemon, detaching itself from the caller process, by triggering a new process to be executed with the same parameters. The new process will be running in the background for as long as the profile is running.