### PR TITLE
Add `flatpak install` and general improvements to `start`

### DIFF
--- a/cmd/cli/flatpak.go
+++ b/cmd/cli/flatpak.go
@@ -60,6 +60,35 @@ qubesome flatpak run -profile <profile> org.kde.francis     - Run the org.kde.fr
 					)
 				},
 			},
+			{
+				Name:  "install",
+				Usage: "executes flatpak install on Host for each Flatpak in the Qubesome profile",
+				Description: `Examples:
+
+qubesome flatpak install
+`,
+				Arguments: []cli.Argument{
+					&cli.StringArg{
+						Name:        "profile",
+						Destination: &targetProfile,
+						Min:         1,
+						Max:         1,
+					},
+				},
+				Action: func(ctx context.Context, cmd *cli.Command) error {
+					prof, err := profileOrActive(targetProfile)
+					if err == nil {
+						targetProfile = prof.Name
+					}
+
+					cfg := profileConfigOrDefault(targetProfile)
+
+					return flatpak.Install(
+						flatpak.WithProfile(targetProfile),
+						flatpak.WithConfig(cfg),
+					)
+				},
+			},
 		},
 	}
 	return cmd

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -25,6 +25,7 @@ var (
 	runner        string
 	commandName   string
 	debug         bool
+	interactive   bool
 )
 
 func RootCommand() *cli.Command {

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/urfave/cli/v3 v3.0.0-beta1
 	github.com/zalando/go-keyring v0.2.6
 	golang.org/x/sys v0.30.0
+	golang.org/x/term v0.28.0
 	google.golang.org/grpc v1.70.0
 	google.golang.org/protobuf v1.36.5
 	gopkg.in/yaml.v3 v3.0.1

--- a/internal/profiles/options.go
+++ b/internal/profiles/options.go
@@ -5,11 +5,12 @@ import (
 )
 
 type Options struct {
-	GitURL  string
-	Path    string
-	Local   string
-	Profile string
-	Runner  string
+	GitURL      string
+	Path        string
+	Local       string
+	Profile     string
+	Runner      string
+	Interactive bool
 }
 
 func WithGitURL(gitURL string) command.Option[Options] {
@@ -39,5 +40,11 @@ func WithProfile(profile string) command.Option[Options] {
 func WithRunner(runner string) command.Option[Options] {
 	return func(o *Options) {
 		o.Runner = runner
+	}
+}
+
+func WithInteractive() command.Option[Options] {
+	return func(o *Options) {
+		o.Interactive = true
 	}
 }

--- a/internal/profiles/profiles.go
+++ b/internal/profiles/profiles.go
@@ -33,6 +33,7 @@ import (
 	"github.com/qubesome/cli/internal/util/xauth"
 	"github.com/qubesome/cli/pkg/inception"
 	"golang.org/x/sys/execabs"
+	"golang.org/x/term"
 )
 
 var (
@@ -234,7 +235,7 @@ func Start(runner string, profile *types.Profile, cfg *types.Config) (err error)
 		}
 	}
 
-	if os.Stdin != nil && len(imgs) > 1 {
+	if len(imgs) > 1 && term.IsTerminal(int(os.Stdout.Fd())) {
 		if proceed("Not all workload images are present. Start loading them on the background?") {
 			go images.PreemptWorkloadImages(binary, cfg)
 		}


### PR DESCRIPTION
Add the ability to kick-off the installation of all flatpaks needed by a given profile. That way, when jumping into a new underlying host the user can hydrate Flatpak dependencies with `qubesome flatpak install`.

A new `-i` has been added to `qubesome start` to help folks onboarding new Window Manager support or troubleshooting issues with the starting process of an existing one.