### PR TITLE
Improve AMD GPU support

### DIFF
--- a/internal/util/gpu/gpu.go
+++ b/internal/util/gpu/gpu.go
@@ -1,6 +1,9 @@
 package gpu
 
-import "os/exec"
+import (
+	"os"
+	"os/exec"
+)
 
 // Supported checks whether GPU sharing is supported by the system, based
 // on either NVidia or AMD toolkits being instead.
@@ -16,8 +19,8 @@ func Supported(runner string) (string, bool) {
 		}
 		return "--gpus=all", true
 	}
-	// AMD GPU.
-	if path, _ := exec.LookPath("rocm-smi"); path != "" {
+	// AMD GPU based on AMD Kernel Fusion Driver.
+	if _, err := os.Stat("/dev/kfd"); err == nil {
 		return "--device=/dev/kfd", true
 	}
 	return "", false


### PR DESCRIPTION
Depending on the ROCm version, the binaries are not added to the PATH. Checking for /dev/kfd seems to be a more consistent way to check whether the AMD Kernel Fusion Driver is in place, which is what AMD uses.