### PR TITLE
run: Add support for X11/Wayland and NoGPU specific args

### DIFF
--- a/internal/qubesome/run.go
+++ b/internal/qubesome/run.go
@@ -184,6 +184,16 @@ func runner(in WorkloadInfo, runnerOverride string, headless bool) error {
 		slog.Debug("unknown objects mismatch", "w", w, "ew", ew)
 	}
 
+	if strings.EqualFold(os.Getenv("XDG_SESSION_TYPE"), "wayland") {
+		ew.Workload.Args = append(ew.Workload.Args, ew.Workload.WaylandArgs...)
+	} else {
+		ew.Workload.Args = append(ew.Workload.Args, ew.Workload.X11Args...)
+	}
+
+	if len(ew.Workload.HostAccess.Gpus) == 0 {
+		ew.Workload.Args = append(ew.Workload.Args, ew.Workload.NoGPUArgs...)
+	}
+
 	ew.Workload.Args = append(ew.Workload.Args, in.Args...)
 
 	if runnerOverride != "" {

--- a/internal/types/workload.go
+++ b/internal/types/workload.go
@@ -10,10 +10,17 @@ import (
 )
 
 type Workload struct {
-	Name           string     `yaml:"name"`
-	Image          string     `yaml:"image"`
-	Command        string     `yaml:"command"`
-	Args           []string   `yaml:"args"`
+	Name    string `yaml:"name"`
+	Image   string `yaml:"image"`
+	Command string `yaml:"command"`
+	// Args defines X11-specific arguments.
+	Args []string `yaml:"args"`
+	// X11Args defines X11-specific arguments.
+	X11Args []string `yaml:"x11Args"`
+	// WaylandArgs defines Wayland-specific arguments.
+	WaylandArgs []string `yaml:"waylandArgs"`
+	// NoGPUArgs defines arguments to be used when no GPU is available.
+	NoGPUArgs      []string   `yaml:"noGpuArgs"`
 	SingleInstance bool       `yaml:"singleInstance"`
 	HostAccess     HostAccess `yaml:"hostAccess"`
 	MimeApps       []string   `yaml:"mimeApps"`


### PR DESCRIPTION
This provides an easier way to customise a given workload so that it will work effectively regardless of running it on Wayland or X11. It will also avoid issues when no GPU is available.

Relates to #2.