### PR TITLE
goreleaser: Add support for new cosign bundle and update archives format config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,8 +19,7 @@ builds:
       - CGO_ENABLED=0
 
 archives:
-  - id: default
-    format: binary
+  - formats: [ 'binary' ]
 
 signs:
   - cmd: cosign


### PR DESCRIPTION
This fixes the [failure](https://github.com/qubesome/cli/actions/runs/19069106283) in the release pipeline.